### PR TITLE
Proposed PR for changing the implementation of lazy lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 
 ## Description of the Coq content
 
-There are 26 Coq vernacular files, here presented in useful order (based on the [dependency graph](coq/dependency_graph.txt)).
+There are 26 Coq vernacular files, here presented in useful order (based on the [dependency graph](coq/dependency_graph.txt)). According to `coqwc` the whole code comprises a total of around 2500 lines of code: around 1130 loc for specifications, 1230 loc for proofs and 300 lines for comments.
+  
 * [`list_utils.v`](coq/list_utils.v) --- One of the biggest files, all concerning list operations, list permutations, the lifting of relations to lists and segments of the natural numbers -- auxiliary material with use at many places.
 * [`wf_utils.v`](coq/wf_utils.v) --- The subtle tactics for measure recursion in one or two arguments with a nat-valued measure function -- this is crucial for smooth extraction throughout.
 * [`llist.v`](coq/llist.v) --- Some general material on coinductive lists, in particular proven finite ones (including append for those), but also the rotate operation of Okasaki.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 ## What is this repository for?
 
 * Coq v8.8.1 or v8.8.2 implementation of breadth-first numbering à la Okasaki and variations thereof
-* It is also possible to compile the project under Coq v8.7.1 but the `Makefile` is not compatible
-  and should be regenerated for v8.7.1 with the command `coq_makefile -f _CoqProject -o Makefile`
+* It is also possible to compile the project under Coq v8.7.* but the `Makefile` is not compatible
+  and should be regenerated for v8.7.* with the command `coq_makefile -f _CoqProject -o Makefile`
 
 ## How do I use it?
 

--- a/coq/dependency_graph.txt
+++ b/coq/dependency_graph.txt
@@ -1,7 +1,7 @@
 list_utils.v:
 wf_utils.v:
-llist.v:
 
+llist.v: wf_utils.v
 wf_example.v:	wf_utils.v
 
 zip.v: 		list_utils.v

--- a/coq/fifo_3llists.v
+++ b/coq/fifo_3llists.v
@@ -25,35 +25,34 @@ Section fifo_three_lazy_lists.
   (** From "Simple and Efficient Purely Functional Queues and Deques" by Chris Okasaki 
           Journal of Functional Programming 5(4):583-592
 
-      this implements and prove the spec from page 587 with lazy lists (llist)
-      with invariant (l,r,l') : llength l' + llength r = llength l
+      this implements and prove the spec from page 587 with lazy lists 
+      with invariant (l,r,l') : lazy_length l' + lazy_length r = lazy_length l
 
-
-      let rec llist_rotate l r a := match r with
+      let rec lazy_rotate l r a := match r with
         | lcons y r -> match l with
           | lnil      -> lcons y a
-          | lcons x l -> lcons x (llist_rotate l' r' (lcons y a))
+          | lcons x l -> lcons x (lazy_rotate l' r' (lcons y a))
 
-      let fifo_3q_nil = (lnil,lnil,lnil)
+      let empty = (lnil,lnil,lnil)
 
-      let fifo_3q_make l r l' = match l' with
-        | lnil       -> let l' = llist_rotate l r lnil in (l',lnil,l')
+      let make l r l' = match l' with
+        | lnil       -> let l' = lazy_rotate l r lnil in (l',lnil,l')
         | lcons _ l' -> (l, r, l')
 
-      let fifo_3q_enq (l,r,l') x = fifo_3q_make l (lcons x r) l'
+      let enq (l,r,l') x = make l (lcons x r) l'
 
-      let fifo_3q_deq (lcons x l,r,l') = (x,fifo_3q_make l r l')
+      let deq (lcons x l,r,l') = (x,make l r l')
 
-      let fifo_3q_void (l,r,n) = l = lnil
+      let void (l,r,n) = l = lnil
 
     *)
 
   Variable X : Type.
 
-  Implicit Types (l r : llist X).
+  Implicit Types (l r : lazy_list X).
 
-  Let Q_spec (c : llist X * llist X * llist X) :=
-    match c with (l,r,l') => exists Hl Hr Hl', lfin_length l' Hl' + lfin_length r Hr = lfin_length l Hl end.
+  Let Q_spec (c : lazy_list X * lazy_list X * lazy_list X) :=
+    match c with (l,r,l') => lazy_length l' + lazy_length r = lazy_length l end.
 
   Definition fifo := sig Q_spec.
 
@@ -62,130 +61,71 @@ Section fifo_three_lazy_lists.
   Definition f2l : fifo -> list X.
   Proof.
     intros (((l,r),l') & H).
-    refine (llist_list l _ ++ rev (llist_list r _));
-    destruct H as (? & ? & _); assumption.
-  Defined.
-
-  Let fifo_nil_val : fifo.
-  Proof.
-    refine (exist _ (lnil,lnil,lnil) _).
-    exists (lfin_lnil _), (lfin_lnil _), (lfin_lnil _); simpl.
-    rewrite lfin_length_fix_0; auto.
+    exact (lazy2list l ++ rev (lazy2list r)).
   Defined.
 
   Definition empty : { q | f2l q = nil }.
-  Proof. exists fifo_nil_val; trivial. Defined.
-
-  Definition make l r l' : (exists Hl Hr Hl', lfin_length l' Hl' + lfin_length r Hr = 1 + lfin_length l Hl) -> fifo.
   Proof.
-    destruct l' as [ | x l'' ]; intros E.
-    + cut (lfin l); [ intros Hl1 | ].
-      cut (lfin r); [ intros Hr1 | ].
-      2-3 : cycle 1.
-      cut (lfin_length r Hr1 = 1 + lfin_length l Hl1); [ intros E1 | ].
-      2-4 : cycle 1.
-      refine (let l'' := @llist_rotate _ l r lnil Hl1 Hr1 (@lfin_lnil _) E1 
-              in exist _ (l'',lnil,l'') _).
-      all: cycle 1.
-      * destruct E as (? & ? & _); assumption.
-      * destruct E as (? & ? & _); assumption.
-      * destruct E as (Hl & Hr & Hl' & E).
-        rewrite lfin_length_fix_0 in E.
-        rewrite (lfin_length_eq _ Hr), (lfin_length_eq _ Hl); auto.
-      * exists (lfin_rotate _ _ (@lfin_lnil _) E1), 
-             (@lfin_lnil _),
-             (lfin_rotate _ _ (@lfin_lnil _) E1).
-        unfold l''; rewrite llist_rotate_length; auto.
-    + refine (exist _ (l,r,l'') _).
-      destruct E as (Hl & Hr & Hl'' & E).
-      exists Hl, Hr, (lfin_inv Hl'').
-      rewrite lfin_length_fix_1 in E; omega.
+    assert (H : Q_spec (lazy_nil,lazy_nil,lazy_nil)).
+    { red; rewrite lazy_length_nil; auto. }
+    exists (exist _ _ H).
+    unfold f2l; simpl; auto.
   Defined.
 
-  Hint Resolve llist_list_eq.
-
-  Fact make_spec l r l' Hl Hr H : llist_list l Hl ++ rev (llist_list r Hr) = f2l (@make l r l' H).
+  Definition make l r l' : lazy_length l' + lazy_length r = 1 + lazy_length l -> { m | lazy2list l ++ rev (lazy2list r) = f2l m }.
   Proof.
-    destruct H as (Hl1 & Hr1 & Hl' & E).
-    unfold f2l, make; destruct l' as [ | x l' ].
-    + rewrite (llist_rotate_eq _ _ (@lfin_lnil _) _).
-      repeat rewrite llist_list_fix_0; simpl.
-      repeat rewrite <- app_nil_end; repeat (f_equal; auto).
-    + repeat (f_equal; auto).
-  Qed.
-
-  Let fifo_enq_val q x : fifo.
-  Proof.
-    destruct q as (((l,r),l') & H).
-    refine (@make l (lcons x r) l' _).
-    destruct H as (Hl & Hr & Hl' & E).
-    exists Hl, (lfin_lcons _ Hr), Hl'.
-    rewrite lfin_length_fix_1, (lfin_length_eq _ Hr); omega.
+    induction l' as [ | x l'' _ ] using lazy_list_rect; intros E.
+    + rewrite lazy_length_nil in E; simpl in E.
+      destruct (lazy_rotate l r lazy_nil E) as (l'' & H'').
+      assert (H : Q_spec (l'',lazy_nil,l'')).
+      { red; rewrite lazy_length_nil; omega. }
+      exists (exist _ _ H).
+      unfold Q_spec; simpl.
+      rewrite H''; simpl.
+      rewrite lazy2list_nil.
+      repeat rewrite <- app_nil_end; trivial.
+    + assert (H : Q_spec (l,r,l'')).
+      { red; rewrite lazy_length_cons in E; omega. }
+      exists (exist _ _ H).
+      unfold Q_spec; simpl; auto.
   Defined.
 
-  Definition enq q x : { q' | f2l q' = f2l q ++ x :: nil }.
-  Proof.  
-    exists (fifo_enq_val q x).
-    revert q x.
-    unfold fifo_enq_val.
-    intros  (((l,r),l') & Hl & Hr & Hl' & E) x.
-    rewrite <- (@make_spec _ _ _ Hl (lfin_lcons _ Hr)).
-    unfold f2l.
-    rewrite llist_list_fix_1, app_ass; trivial.
+  Definition enq : forall q x, { q' | f2l q' = f2l q ++ x :: nil }.
+  Proof.
+    intros (((l,r),l') & H) x.
+    refine (let (m,Hm) := make l (lazy_cons x r) l' _ in _).
+    + red in H; rewrite lazy_length_cons; omega.
+    + exists m.
+      simpl; rewrite <- Hm.
+      rewrite lazy2list_cons, app_ass; simpl; auto.
   Defined.
 
-  Let fifo_deq_val q : f2l q <> nil -> X * fifo.
+  Definition deq : forall q, f2l q <> nil -> { c : X * fifo | let (x,q') := c in f2l q = x::f2l q' }.
   Proof.
-    destruct q as (((l,r),l') & H); revert H.
-    refine (match l with 
-      | lnil      => fun H1 H2 => _
-      | lcons x l => fun H1 H2 => (x,@make l r l' _)
-    end); [ exfalso | ]; destruct H1 as (Hl & Hr & Hl' & E).
-    + unfold f2l in H2.
-      destruct r.
-      * do 2 rewrite llist_list_fix_0 in H2; destruct H2; trivial.
-      * rewrite lfin_length_fix_1, lfin_length_fix_0 in E; omega.
-    + exists (lfin_inv Hl), Hr, Hl'.
-      rewrite E, lfin_length_fix_1; auto.
+    intros (((l,r),l') & H); revert H; simpl.
+    induction l as [ | x l _ ] using lazy_list_rect.
+    + induction r as [ | y r _ ] using lazy_list_rect; intros H1 H2; exfalso.
+      * destruct H2; rewrite lazy2list_nil; auto.
+      * rewrite lazy_length_cons, lazy_length_nil in H1; omega.
+    + intros H1 H2.
+      refine (let (m,Hm) := @make l r l' _ in _).
+      * rewrite lazy_length_cons in H1; omega.
+      * exists (x,m).
+        rewrite lazy2list_cons; simpl; f_equal; auto.
   Defined.
 
-  Definition deq q : f2l q <> nil -> { c : X * fifo | let (x,q') := c in f2l q = x::f2l q' }.
+  Definition void : forall q, { b : bool | b = true <-> f2l q = nil }.
   Proof.
-    intros Hq.
-    exists (fifo_deq_val q Hq).
-    revert q Hq.  
-    unfold fifo_deq_val.
-    intros ((([ | x l],r),n) & Hl & Hr & Hl' & E) Hq.
-    + exfalso.
-      unfold f2l in Hq.
-      destruct r.
-      * do 2 rewrite llist_list_fix_0 in Hq; destruct Hq; trivial.
-      * rewrite lfin_length_fix_1, lfin_length_fix_0 in E; omega.
-    + rewrite <- (@make_spec _ _ _ (lfin_inv Hl) Hr).
-      unfold f2l.
-      rewrite llist_list_fix_1; auto.
-  Defined.
-
-  Let fifo_void_val : fifo -> bool.
-  Proof.
-    intros ((([ | x l],_),_) & _).
-    + exact true.
-    + exact false.
-  Defined.
-
-  Definition void q : { b : bool | b = true <-> f2l q = nil }.
-  Proof.
-    exists (fifo_void_val q).
-    revert q.
-    unfold f2l, fifo_void_val.
-    intros ((([ | x l],r),n) & Hl & Hr & Hl' & E).
-    + split; auto; intros _. 
-      rewrite llist_list_fix_0.
-      destruct r.
-      * rewrite llist_list_fix_0; auto.
-      * rewrite lfin_length_fix_0, lfin_length_fix_1 in E; omega.
-    + split; try discriminate.
-      rewrite llist_list_fix_1; discriminate.
+    intros (((l,r),l') & H).
+    induction l as [ | x l _ ] using lazy_list_rect; red in H.
+    + exists true; simpl.
+      split; auto; intros _.
+      induction r as [ | y r _ ] using lazy_list_rect.
+      * rewrite lazy2list_nil; auto.
+      * rewrite lazy_length_cons, lazy_length_nil in H; simpl in H; omega.
+    + exists false; simpl.
+      split; try discriminate.
+      rewrite lazy2list_cons; discriminate.
   Defined.
 
 End fifo_three_lazy_lists.

--- a/coq/fifo_3llists.v
+++ b/coq/fifo_3llists.v
@@ -25,7 +25,7 @@ Section fifo_three_lazy_lists.
   (** From "Simple and Efficient Purely Functional Queues and Deques" by Chris Okasaki 
           Journal of Functional Programming 5(4):583-592
 
-      this implements and prove the spec from page 587 with lazy lists 
+      this implements and proves the spec from page 587 with lazy lists
       with invariant (l,r,l') : lazy_length l' + lazy_length r = lazy_length l
 
       let rec lazy_rotate l r a := match r with

--- a/extracted_ocaml/bfr.mli
+++ b/extracted_ocaml/bfr.mli
@@ -30,19 +30,22 @@ and 'x __llist =
 | Lnil
 | Lcons of 'x * 'x llist
 
-val llist_list : 'a1 llist -> 'a1 list
+type 'x lazy_list = 'x llist
 
-val llist_rotate : 'a1 llist -> 'a1 llist -> 'a1 llist -> 'a1 llist
+val lazy2list : 'a1 lazy_list -> 'a1 list
+
+val lazy_rotate :
+  'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list
 
 module FIFO_3llists :
  sig
-  type 'x fifo = (('x llist*'x llist)*'x llist)
+  type 'x fifo = (('x lazy_list*'x lazy_list)*'x lazy_list)
 
   val f2l : 'a1 fifo -> 'a1 list
 
   val empty : 'a1 fifo
 
-  val make : 'a1 llist -> 'a1 llist -> 'a1 llist -> 'a1 fifo
+  val make : 'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list -> 'a1 fifo
 
   val enq : 'a1 fifo -> 'a1 -> 'a1 fifo
 

--- a/extracted_ocaml/fifo.ml
+++ b/extracted_ocaml/fifo.ml
@@ -97,56 +97,57 @@ and 'x __llist =
 | Lnil
 | Lcons of 'x * 'x llist
 
-(** val llist_list : 'a1 llist -> 'a1 list **)
+type 'x lazy_list = 'x llist
 
-let rec llist_list ll =
+(** val lazy2list : 'a1 lazy_list -> 'a1 list **)
+
+let rec lazy2list s =
   match Lazy.force
-  ll with
+  s with
   | Lnil -> []
-  | Lcons (x, ll0) -> x::(llist_list ll0)
+  | Lcons (x, s0) -> x::(lazy2list s0)
 
-(** val llist_rotate : 'a1 llist -> 'a1 llist -> 'a1 llist -> 'a1 llist **)
+(** val lazy_rotate :
+    'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list **)
 
-let rec llist_rotate l r a =
+let rec lazy_rotate u v a =
   match Lazy.force
-  r with
+  v with
   | Lnil -> assert false (* absurd case *)
-  | Lcons (y, r') ->
+  | Lcons (x, s) ->
     (match Lazy.force
-     l with
-     | Lnil -> lazy (Lcons (y, a))
-     | Lcons (x, l') ->
-       lazy (Lcons (x, (llist_rotate l' r' (lazy (Lcons (y, a)))))))
+     u with
+     | Lnil -> lazy (Lcons (x, a))
+     | Lcons (x0, s0) ->
+       lazy (Lcons (x0, (lazy_rotate s0 s (lazy (Lcons (x, a)))))))
 
 module FIFO_3llists =
  struct
-  type 'x fifo = (('x llist*'x llist)*'x llist)
+  type 'x fifo = (('x lazy_list*'x lazy_list)*'x lazy_list)
 
   (** val f2l : 'a1 fifo -> 'a1 list **)
 
   let f2l = function
-  | p,_ -> let l,r = p in app (llist_list l) (rev (llist_list r))
+  | p,_ -> let l,r = p in app (lazy2list l) (rev (lazy2list r))
 
   (** val empty : 'a1 fifo **)
 
   let empty =
     ((lazy Lnil),(lazy Lnil)),(lazy Lnil)
 
-  (** val make : 'a1 llist -> 'a1 llist -> 'a1 llist -> 'a1 fifo **)
+  (** val make :
+      'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list -> 'a1 fifo **)
 
   let make l r l' =
     match Lazy.force
     l' with
-    | Lnil -> let l'' = llist_rotate l r (lazy Lnil) in (l'',(lazy Lnil)),l''
-    | Lcons (_, l'') -> (l,r),l''
+    | Lnil -> let s = lazy_rotate l r (lazy Lnil) in (s,(lazy Lnil)),s
+    | Lcons (_, s) -> (l,r),s
 
   (** val enq : 'a1 fifo -> 'a1 -> 'a1 fifo **)
 
-  let enq q =
-    let fifo_enq_val = fun q0 x ->
-      let p,x0 = q0 in let l,r = p in make l (lazy (Lcons (x, r))) x0
-    in
-    (fun x -> fifo_enq_val q x)
+  let enq q x =
+    let p,x0 = q in let l,r = p in make l (lazy (Lcons (x, r))) x0
 
   (** val deq : 'a1 fifo -> ('a1*'a1 fifo) **)
 
@@ -156,15 +157,15 @@ module FIFO_3llists =
     (match Lazy.force
      l with
      | Lnil -> assert false (* absurd case *)
-     | Lcons (x0, l0) -> x0,(make l0 r x))
+     | Lcons (x0, s) -> x0,(make s r x))
 
   (** val void : 'a1 fifo -> bool **)
 
   let void = function
   | p,_ ->
-    let l0,_ = p in
+    let l,_ = p in
     (match Lazy.force
-     l0 with
+     l with
      | Lnil -> true
      | Lcons (_, _) -> false)
  end

--- a/extracted_ocaml/fifo.mli
+++ b/extracted_ocaml/fifo.mli
@@ -43,19 +43,22 @@ and 'x __llist =
 | Lnil
 | Lcons of 'x * 'x llist
 
-val llist_list : 'a1 llist -> 'a1 list
+type 'x lazy_list = 'x llist
 
-val llist_rotate : 'a1 llist -> 'a1 llist -> 'a1 llist -> 'a1 llist
+val lazy2list : 'a1 lazy_list -> 'a1 list
+
+val lazy_rotate :
+  'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list
 
 module FIFO_3llists :
  sig
-  type 'x fifo = (('x llist*'x llist)*'x llist)
+  type 'x fifo = (('x lazy_list*'x lazy_list)*'x lazy_list)
 
   val f2l : 'a1 fifo -> 'a1 list
 
   val empty : 'a1 fifo
 
-  val make : 'a1 llist -> 'a1 llist -> 'a1 llist -> 'a1 fifo
+  val make : 'a1 lazy_list -> 'a1 lazy_list -> 'a1 lazy_list -> 'a1 fifo
 
   val enq : 'a1 fifo -> 'a1 -> 'a1 fifo
 


### PR DESCRIPTION
Hi Ralph,

Here is my proposed PR for changing `llist.v` and `fifo_3llists.v` according to the new implementation of lazy lists than hides the lfin predicate.

I tried to use names so as to be compatible with what is written in the paper. No new file either. Simply overwritten `llist.v` and updated `fifo_3llists.v`.

Could you check if it compiles for you before I merge ? I tried v8.8.1 and v8.7.2.

I also upated the README so that it contains some comments about the length of the Coq code.

Best,
D.